### PR TITLE
Fix gocheck tests double run

### DIFF
--- a/gocheck_two_packages_one_folder/init_package2_test.go
+++ b/gocheck_two_packages_one_folder/init_package2_test.go
@@ -6,11 +6,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type TestPackageSuite struct {
-}
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+type TestPackageSuite struct {}
 
 func init() {
 	Suite(&TestPackageSuite{})


### PR DESCRIPTION
Gocheck  registration should happen at most once. 

The problem is, that we have two call of `TestingT` in this directory:
 
    func Test(t *testing.T) { TestingT(t) }

We need to remove it and make sure there is at most one such call.